### PR TITLE
Fixed demo build

### DIFF
--- a/demos/browserify/package.json
+++ b/demos/browserify/package.json
@@ -14,6 +14,7 @@
     "form-generator-react": "^1.0.4",
     "jquery": "^2.1.4",
     "react": "^0.13.3",
+    "react-dom": "^0.14.7",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Error: Cannot find module 'react-dom'

An error was displayed while trying to build files:  'gulp browserify'
